### PR TITLE
unpaywall: add primo-studio config file for tracking

### DIFF
--- a/packages/unpaywall/README.md
+++ b/packages/unpaywall/README.md
@@ -6,11 +6,11 @@ Add 'Open Access available via unpaywall' link to `search-result-avaliability-li
 
 **On Item Display...**
 /primo-explore/fulldisplay
-![unpaywall-link_fulldisplay](img/unpaywall-link_fulldisplay.png)
+![unpaywall-link_fulldisplay](https://github.com/bulib/primo-explore-bu/blob/master/packages/unpaywall/img/unpaywall-link_fulldisplay.png)
 
 **On Results List (optionally)...**
 /primo-explore/search
-![unpaywall-link_results-list](img/unpaywall-link_results-list.png)
+![unpaywall-link_results-list](https://github.com/bulib/primo-explore-bu/blob/master/packages/unpaywall/img/unpaywall-link_results-list.png)
 
 ### Background
 
@@ -69,7 +69,7 @@ $ npm install --save-dev primo-explore-unpaywall
 
 this should add the following line to your `package.json` file...
 ```json
-"primo-explore-unpaywall": "^1.0.1"
+"primo-explore-unpaywall": "^1.1.3"
 ```
 
 and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-unpaywall` 

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -5,7 +5,7 @@
   "what": "bulib-unpaywall",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
   "npmid": "primo-explore-unpaywall",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "hook": "prm-search-result-avaliability-line-after",
   "config": {
     "form": [

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -1,0 +1,84 @@
+{
+  "face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
+  "notes": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
+  "who": "BU Libraries",
+  "what": "bulib-unpaywall",
+  "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
+  "npmid": "primo-explore-unpaywall",
+  "version": "1.0.4",
+  "hook": "prm-search-result-avaliability-line-after",
+  "config": {
+    "form": [
+      {
+        "key": "email",
+        "type": "input",
+        "templateOptions": {
+          "required": true,
+          "label": "Email used for Unpaywall API access",
+          "placeholder": "username@institution.edu"
+        }
+      },
+      {
+        "key": "showOnResultsPage",
+        "type": "select",
+        "defaultValue": true,
+        "templateOptions": {
+          "required": false,
+          "label": "Include OA links on search results page",
+          "options":[
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "showVersionLabel",
+        "type": "select",
+        "defaultValue": true,
+        "templateOptions": {
+          "label": "Add version qualification to link display ('Submitted', 'Accepted')",
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "logToConsole",
+        "type": "select",
+        "defaultValue": true,
+        "templateOptions": {
+          "label": "(debug) Log debug messages to console",
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "showDebugTable",
+        "type": "select",
+        "defaultValue": false,
+        "templateOptions": {
+          "label": "(debug) Display table of values from Item PNX",
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "publishEvents",
+        "type": "select",
+        "defaultValue": true,
+        "templateOptions": {
+          "label": "(debug) Determine whether click/usage events are published to Analytics",
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -5,7 +5,7 @@
   "what": "bulib-unpaywall",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
   "npmid": "primo-explore-unpaywall",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "hook": "prm-search-result-avaliability-line-after",
   "config": {
     "form": [
@@ -78,7 +78,8 @@
             { "name": "false", "value": false }
           ]
         }
-      }
+      },
+      { "key": "logEvent" }
     ]
   }
 }

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -3,12 +3,19 @@ var logEventToGoogleAnalytics = function(category, action, label){
 }
 
 angular.module('bulibUnpaywall', [])
-  .controller('unpaywallController', ['unpaywallConfig', '$http', 
-    function(unpaywallConfig, $http) {
+  .controller('unpaywallController', ['$http', '$injector',
+    function($http, $injector) {
       var self = this;  // 'this' changes scope inside of the $http.get(). 'self' is easier to track/trace
       var item = this.parentCtrl.result;  // item data is stored in 'prmSearchResultAvailability' (its parent)
       
-      // obtain custom configuration information from 'unpaywallConfig' constant (with defaults)
+      // obtain custom configuration information from 'unpaywallConfig' constant (with defaults
+      var unpaywallConfig = {};
+      if($injector.has('unpaywallConfig')){ 
+        unpaywallConfig = $injector.get('unpaywallConfig');
+      }
+      if($injector.has('primoExploreUnpaywallStudioConfig')){
+        unpaywallConfig = $injector.get('primoExploreUnpaywallStudioConfig');
+      }
       self.logToConsole = unpaywallConfig.logToConsole || false;
       self.publishEvents = unpaywallConfig.publishEvents || true;
       self.showVersionLabel = unpaywallConfig.showVersionLabel || false;

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -8,7 +8,7 @@ angular.module('bulibUnpaywall', [])
       var self = this;  // 'this' changes scope inside of the $http.get(). 'self' is easier to track/trace
       var item = this.parentCtrl.result;  // item data is stored in 'prmSearchResultAvailability' (its parent)
       
-      // obtain custom configuration information from 'unpaywallConfig' constant (with defaults
+      // obtain custom configuration information from 'unpaywallConfig' or primo-studio constant 
       var unpaywallConfig = {};
       if($injector.has('unpaywallConfig')){ 
         unpaywallConfig = $injector.get('unpaywallConfig');
@@ -16,6 +16,11 @@ angular.module('bulibUnpaywall', [])
       if($injector.has('primoExploreUnpaywallStudioConfig')){
         unpaywallConfig = $injector.get('primoExploreUnpaywallStudioConfig');
       }
+
+      // provide 'unpaywall' organization with default value including some context that it's from us (for rate-limiting)
+      self.email = unpaywallConfig.email || "primo-explore-unpaywall@npmjs.com";
+
+      // provide additional customization options (with defaults)
       self.logToConsole = unpaywallConfig.logToConsole || false;
       self.publishEvents = unpaywallConfig.publishEvents || true;
       self.showVersionLabel = unpaywallConfig.showVersionLabel || false;
@@ -58,7 +63,9 @@ angular.module('bulibUnpaywall', [])
           self.logEventToAnalytics('unpaywall', 'api-call', self.listOrFullViewLabel);
 
           // make the actual call to unpaywall API
-          $http.get("https://api.oadoi.org/v2/"+self.doi+"?email="+unpaywallConfig.email).then(
+          var apiUrl = "https://api.oadoi.org/v2/"+self.doi+"?email="+self.email;
+          self.logMessageToConsole("-> making 'api-call' to " + apiUrl);
+          $http.get(apiUrl).then(
             function(successResponse){
               // if there is a "best open access location", save it so it can be used in the template above
               var best_oa_location = successResponse.data.best_oa_location;

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -22,11 +22,19 @@ angular.module('bulibUnpaywall', [])
 
       // provide additional customization options (with defaults)
       self.logToConsole = unpaywallConfig.logToConsole || false;
-      self.publishEvents = unpaywallConfig.publishEvents || true;
       self.showVersionLabel = unpaywallConfig.showVersionLabel || false;
       self.showDebugTable = unpaywallConfig.showDebugTable || false;
       self.logEvent = unpaywallConfig.logEvent || logEventToGoogleAnalytics;
-      var showOnResults = unpaywallConfig.showOnResultsPage || true;
+
+      // other customization options defaulted to true
+      self.publishEvents = true;
+      if(Object.keys(unpaywallConfig).includes("publishEvents")){
+        self.publishEvents = unpaywallConfig.publishEvents;
+      }
+      var showOnResults = true;
+      if(Object.keys(unpaywallConfig).includes("showOnResultsPage")){
+        showOnResults = unpaywallConfig.showOnResultsPage;
+      }
 
       // obtain contextual info on whether you're on the result list of the full item view
       var onFullView = this.parentCtrl.isFullView || this.parentCtrl.isOverlayFullView;
@@ -65,7 +73,7 @@ angular.module('bulibUnpaywall', [])
           // make the actual call to unpaywall API
           var apiUrl = "https://api.oadoi.org/v2/"+self.doi+"?email="+self.email;
           self.logMessageToConsole("-> making 'api-call' to " + apiUrl);
-          $http.get(apiUrl).then(
+          $http.get(encodeURI(apiUrl)).then(
             function(successResponse){
               // if there is a "best open access location", save it so it can be used in the template above
               var best_oa_location = successResponse.data.best_oa_location;
@@ -86,12 +94,13 @@ angular.module('bulibUnpaywall', [])
                 self.best_oa_version = (best_oa_version.includes("submit"))? "Submitted" : "Accepted";
               }
             }, function(errorResponse){
-              self.logMessageToConsole("[" + errorResponse.status + "] error calling unpaywall API: " +  errorResponse.statusText);
-            });
+              self.logMessageToConsole("[error status: " + errorResponse.status + "] error calling unpaywall API: " +  errorResponse.statusText);
+            }
+          );
         }
 
       }catch(e){
-        logUnpaywallMessageToConsole("error caught in unpaywallController: " + e.message);
+        self.logMessageToConsole("error caught in unpaywallController: " + e.message);
       }
     }
   ])


### PR DESCRIPTION
### Description of Changes
- add `features.json` used to add the customization to [primo studio](https://github.com/primousers/primostudio) ([pull request](https://github.com/primousers/primostudio/pull/37))
- switch out `unpaywallConfig` dependency for `$injector`-based approach allowing Primo Studio configuration (in addition to the code)
- **bugfix** to actually use the `email` address specified in the config 

### Screenshots
![primo-studio screenshot with config popup](https://user-images.githubusercontent.com/5565284/54556892-4ef04c00-4990-11e9-825c-63c5bbfe17ae.png)
