### PR TITLE
unpaywall: Add 'overrideOACheck' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ assorted customizations to Ex Libris Primo New UI created, consumed, and maintai
 
 |name|npm package|description|
 |:------|:-----|:----------|
-|`unpaywall`|[![npm package](https://img.shields.io/npm/v/primo-explore-unpaywall.svg)](https://www.npmjs.com/package/primo-explore-unpaywall)|add 'Open Access available via unpaywall' link to `search-result-avaliability-line-after`|
+|`unpaywall`|[![npm package](https://img.shields.io/npm/v/primo-explore-unpaywall.svg)](https://www.npmjs.com/package/primo-explore-unpaywall)|add 'Open Access available via unpaywall' link to `search-result-availability-line-after`|
 |`help-menu`|[![npm package](https://img.shields.io/npm/v/primo-explore-help-menu.svg)](https://www.npmjs.com/package/primo-explore-help-menu)|Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after` (top nav bar)|
 |`outbound-links`|[![npm package](https://img.shields.io/npm/v/primo-explore-outbound-links.svg)](https://www.npmjs.com/package/primo-explore-outbound-links)|add event tracking to outbound links contained in `prm-service-links`|
 

--- a/packages/unpaywall/README.md
+++ b/packages/unpaywall/README.md
@@ -50,10 +50,12 @@ Add 'Open Access available via unpaywall' link to `search-result-avaliability-li
 
 Wherever a `<prm-search-result-availability-after>` tag appears (/primo-explore/search, /primo-explore/fulldisplay), we...
 1. look in its parentController (`prmSearchResultAvailability`) for the item info contained in it's `result` variable
-2. if there's a doi (`doi`) in there and it's not already marked as open access (`oa`) use it to make a call to
+2. if there's a doi (`doi`) in there and it's not already marked as open access (`oa`)* use it to make a call to
   the afore-mentioned unpaywall api.
 3. if that call ends up being successful, look for an open access download link (`successResponse.data.best_oa_location`)
 4. if it has that, grab the url for it and place it right beneath the other "Online Access Available" link.
+
+_note: (*) you can override this OA check (so that a call is made wherever a DOI is found) by setting `overrideOACheck` in your `unpaywallConfig`_
 
 ### Usage
 
@@ -120,6 +122,7 @@ the following table describes describes some additional configuration options th
 |:------|:-----|:----------|
 |`logEvent`|_see example_|here's an opportunity to hook in whatever event tracking you have, (we use google analytics)|
 |`showOnResultsPage`|`true`|determine whether the link is added to each item in the list of results|
+|`overrideOACheck`|`false`|disable the `addata.oa` check so that the unpaywall check runs on all items with an available DOI|
 |`showVersionLabel`|`true`|sometimes the unpaywall OA response qualifies the stage of publication the work was OA-available in (`Submitted`, `Published`, `Accepted`)|
 |`logToConsole`|`true`|controls whether or not messages about what's going on in the component are `console.log()`-ed (visible in inspector)|
 |`showDebugTable`|`false`|the debug table is a quick way to see unpaywall response data for the record in context a really ugly way (used to help troubleshoot, not meant for end users)|

--- a/packages/unpaywall/README.md
+++ b/packages/unpaywall/README.md
@@ -1,6 +1,6 @@
 # `primo-explore-unpaywall` [![npm package](https://img.shields.io/npm/v/primo-explore-unpaywall.svg)](https://www.npmjs.com/package/primo-explore-unpaywall)
 
-Add 'Open Access available via unpaywall' link to `search-result-avaliability-line-after` in Primo New UI
+Add 'Open Access available via unpaywall' link to `search-result-availability-line-after` in Primo New UI
 
 ### Screenshots
 

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -32,6 +32,18 @@
         }
       },
       {
+        "key": "overrideOACheck",
+        "type": "select",
+        "defaultValue": false,
+        "templateOptions": {
+          "label": "(debug) Make unpaywall regardless of OA status",
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
         "key": "showVersionLabel",
         "type": "select",
         "defaultValue": true,

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -5,8 +5,8 @@
   "what": "bulib-unpaywall",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
   "npmid": "primo-explore-unpaywall",
-  "version": "1.1.7",
-  "hook": "prm-search-result-availability-line-after",
+  "version": "1.2.1",
+  "hook": "prm-search-result-availability-line",
   "config": {
     "form": [
       {

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -36,7 +36,7 @@
         "type": "select",
         "defaultValue": false,
         "templateOptions": {
-          "label": "(debug) Make unpaywall regardless of OA status",
+          "label": "(debug) Make unpaywall call regardless of OA status",
           "options": [
             { "name": "true",  "value": true  },
             { "name": "false", "value": false }

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/src/.main.js
+++ b/packages/unpaywall/src/.main.js
@@ -14,6 +14,7 @@ app.component('prmSearchResultAvailabilityLineAfter', {
   .constant('unpaywallConfig', {
     "email":"<your_username>@<your_institution>.edu",
     "showOnResultsPage":true,
+    "overrideOACheck":false,
     "showVersionLabel":true,
     "logToConsole":true,
     "showDebugTable":false,

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -33,6 +33,7 @@ angular.module('bulibUnpaywall', [])
       self.showVersionLabel = (Object.keys(unpaywallConfig).includes("showVersionLabel")) ? unpaywallConfig.showVersionLabel : false;
       self.showDebugTable = (Object.keys(unpaywallConfig).includes("showDebugTable")) ? unpaywallConfig.showDebugTable : false;
       self.showOnResultsPage = (Object.keys(unpaywallConfig).includes("showOnResultsPage")) ? unpaywallConfig.showOnResultsPage : true;
+      self.overrideOACheck = (Object.keys(unpaywallConfig).includes("overrideOACheck")) ? unpaywallConfig.overrideOACheck : false;
       self.logEvent = unpaywallConfig.logEvent || logEventToGoogleAnalytics;
 
       // conditionally log to the console
@@ -70,7 +71,7 @@ angular.module('bulibUnpaywall', [])
           }
 
           // if there's a doi and it's not already open access, ask the oadoi.org for an OA link
-          if (this.doi && !this.is_oa && self.show) {
+          if (this.doi && (!this.is_oa || self.overrideOACheck) && self.show) {
             self.logEventToAnalytics('unpaywall', 'api-call', self.listOrFullViewLabel);
 
             // make the actual call to unpaywall API


### PR DESCRIPTION
### Background
- Jira Ticket: [WEB-132](https://bulibrary.atlassian.net/browse/WEB-132)
- in order to cut down on the number of calls made to unpaywall and to maximize its utility as a "gap-filler" of sorts, we previously only asked Unpaywall for a copy if we didn't already have an OA one on hand
- given unreliability of that `item.pnx.addata.oa` value (and just because that 'one click to download' functionality is pretty handy), we figured we'd add an optional override to add more links.

### Description of Changes
- add new option to `unpaywallConfig` and describe it in README