### PR TITLE
WEB-216: help-menu - Allow end users to specify custom `helpMenuTitle`

### DIFF
--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -2,8 +2,7 @@
 
 Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after` (top nav bar)
 
-
-### Description
+## Description
 
 ![help-menu dialog](https://github.com/bulib/primo-explore-bu/blob/master/packages/help-menu/img/help-menu-preview.gif?raw=true)
 
@@ -13,10 +12,9 @@ Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`
 4. links can be made between entries very simply using anchor tags `#{entry.id}`
 5. if desired, users can open the help menu in a new window to enable multi-tasking
 
+## Usage
 
-### Usage
-
-#### Adding the Package to your view in `primo-explore` 
+### Adding the Package to your view in `primo-explore`
 
 run the following command from within your view's main directory to add it as a dependency.
 
@@ -26,36 +24,36 @@ $ npm install --save-dev primo-explore-help-menu
 
 this should add the following line to your `package.json` file...
 ```json
-"primo-explore-help-menu": "^1.1.4"
+"primo-explore-help-menu": "^1.2.1"
 ```
 
-and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-help-menu` 
-  directory for your current view. the presence of this package should mean that the package was successfully 
+and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-help-menu`
+  directory for your current view. the presence of this package should mean that the package was successfully
   installed and added to your project.
 
-#### Installing/Importing it 
+### Installing/Importing it
 
 from here you'll have to edit your `main.js` (or `config.module.js`) file to `import` the package, and add
-   _both_ `'helpMenuContentDisplay'` and `'helpMenuTopbar'`, to the dependencies inside of your 
+   _both_ `'helpMenuContentDisplay'` and `'helpMenuTopbar'`, to the dependencies inside of your
    `'viewCustom'` module:
 
 ```js
 import 'primo-explore-help-menu';  // import './help-menu.js'
 
 angular.module('viewCustom', ['angularLoad', 'helpMenuContentDisplay',  'helpMenuTopbar'])
-``` 
+```
 
 (see `./src/.main.js` for a working example).
 
-#### Additional Steps
+### Additional Steps
 
 To get the same styling, you'll have to copy or import the `help-menu.css` file to the `css/custom.css` for your view.
   
 If you're using a version from `1.1.0` onward, you'll have to make sure there's a `html/help_en_US.html` included as well.
 
-#### Adding Your Own Content
+### Adding Your Own Content
 
-To add your own content, specify a `list_of_elements` variable within a `constant` object called `'helpMenuConfig'` and 
+To add your own content, specify a `list_of_elements` variable within a `constant` object called `'helpMenuConfig'` and
   attach it to your primo angular module (`app`) like so:
 
 ```js
@@ -80,9 +78,9 @@ Make sure that each object in the list of elements matches the following structu
 
 _note: the [iconset being used](https://material.io/tools/icons/) is from material.io and is included within primo_
 
-#### Additional Customization
+### Additional Customization
 
-the following table describes describes some additional configuration options that are currently afforded to 
+the following table describes describes some additional configuration options that are currently afforded to
   you by the package. an example implementation of this section can be found within this repo at `src/.main.js`:
 
 |name|default|description|
@@ -90,9 +88,10 @@ the following table describes describes some additional configuration options th
 |`logToConsole`|`true`|controls whether or not messages about what's going on in the component are `console.log()`-ed (visible in inspector)|
 |`publishEvents`|`false`|controls whether the `logEventToAnalytics` is actually triggered, ensurng only real traffic is tracked|
 |`logEventToAnalytics`|_see example_|here's an opportunity to hook in whatever event tracking you have, (we use google analytics)|
+|`helpMenuTitle`|`Search Help`|page and popup title displayed at the top of the menu (useful for translations) |
 |`helpMenuWidth`|`500` (px)|the width of the dialog box and associated popup|
 
-### Events Logged
+## Events Logged
 
 All events are logged under the category `help-menu`.
 
@@ -104,16 +103,16 @@ All events are logged under the category `help-menu`.
 
 _note: At BU Libraries, we use Google Analytics to track and log events. Given this, all events emitted follow the  'category > action > label' convention._
 
-### Contributing
+## Contributing
 
-You're more than welcome to fork this repository, make some changes, and contribute it back by 
-  [creating a pull request](https://github.com/bulib/primo-explore-bu/compare). 
+You're more than welcome to fork this repository, make some changes, and contribute it back by
+  [creating a pull request](https://github.com/bulib/primo-explore-bu/compare).
 
-If you have any issues with this package or ideas for how to make it better, don't hesitate to let us know by 
+If you have any issues with this package or ideas for how to make it better, don't hesitate to let us know by
   [submitting a new issue](https://github.com/bulib/primo-explore-bu/issues/new).
 
-In both of these cases, it would help us if you make sure to add on the appropriate 
-  [labels](https://github.com/bulib/primo-explore-bu/labels) (including especially `help-menu`) so that we 
+In both of these cases, it would help us if you make sure to add on the appropriate
+  [labels](https://github.com/bulib/primo-explore-bu/labels) (including especially `help-menu`) so that we
   can keep track of what your pull request or issue relates to.
 
 If you get stuck, send us a message on [our gitter](https://gitter.im/bulib/developers), and we'll try to help you out.

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,9 +1,11 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "./dist/help-menu.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bulib/primo-explore-bu.git"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.1.4",
+  "version": "1.2.1",
   "main": "./dist/help-menu.js",
   "files": ["dist"],
   "repository": {

--- a/packages/help-menu/src/.main.js
+++ b/packages/help-menu/src/.main.js
@@ -15,6 +15,8 @@ app.constant('helpMenuConfig', {
   "list_of_elements":help_menu_items,
   "logToConsole":true,
   "publishEvents":false,
+  "helpMenuTitle":"Search Menu",
+  "helpMenuWidth":500,
   "logEventToAnalytics":function(category, action, label){
     window.ga('send', 'event', category, action, label);
   }

--- a/packages/help-menu/src/help-menu-templates.js
+++ b/packages/help-menu/src/help-menu-templates.js
@@ -3,7 +3,11 @@ const helpMenuHeadContent = `
     <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_arrow_back_24px"
               aria-label="return to help content list" ></prm-icon>
   </md-button>
-  <h2><strong>Search Help</strong><span ng-hide="!entry"> - {{entry.title}}</span></h2>`;
+  <h2>
+    <strong ng-if="helpMenuTitle">{{helpMenuTitle}}</strong>
+    <strong ng-hide="helpMenuTitle">Search Help</strong>
+    <span ng-hide="!entry"> - {{entry.title}}</span>
+  </h2>`;
 
 const helpMenuMainContent = `
   <div ng-if="entry" id="search-help-menu-content" tabindex="-1">

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -42,6 +42,7 @@ let helpMenuHelper = {
     if(Object.keys(config).includes("logToConsole")){ this.logToConsole = config.logToConsole; }
     if(Object.keys(config).includes("publishEvents")){ this.publishEvents = config.publishEvents; }
     if(Object.keys(config).includes("helpMenuWidth")){ this.helpMenuWidth = config.helpMenuWidth; }
+    if(Object.keys(config).includes("helpMenuTitle")){ this.helpMenuTitle = config.helpMenuTitle; }
     if(Object.keys(config).includes("logEventToAnalytics")){ this.logEventToAnalytics = config.logEventToAnalytics; }
     if(Object.keys(config).includes("list_of_elements")){ this.list_of_elements = config.list_of_elements; }
   }
@@ -58,6 +59,7 @@ const mainHelpMenuController = function(helpMenuHelper, $injector, $scope, $time
 
   // gather items in list from helpMenuHelper
   $scope.helpContentList = helpMenuHelper.list_of_elements;
+  $scope.helpMenuTitle = helpMenuHelper.helpMenuTitle;
 
   // modal navigation
   $scope.hide = function() { $mdDialog.hide(); };
@@ -88,10 +90,11 @@ const mainHelpMenuController = function(helpMenuHelper, $injector, $scope, $time
     }
 
     // open the help-menu in a new-window
+    let popup_title = helpMenuHelper.helpMenuTitle || "Search Help Menu";
     let params=`width=${helpMenuHelper.helpMenuWidth},height=800,resizable=0,location=0,menubar=0,scrollbars=yes`;
     helpMenuHelper.logHelpEvent("open-window", help_event_label);
-    let help_popup = open(help_page_url, 'Search Help Menu', params);
-    help_popup.onload = function() { this.document.title = "Search Help Menu"; }
+    let help_popup = open(help_page_url, popup_title, params);
+    help_popup.onload = function() { this.document.title = popup_title; }
 
     // prepare new window to handle 'select-option' via the '#', and close the dialog
     help_popup.addEventListener('hashchange',$scope.setEntryIdFromHash,true);


### PR DESCRIPTION
Resolves #12 

### Background 
- @ZahraMousavi from the Royal Danish Library requested the customization to facilitate translation 

### Description of Changes
- add `helpMenuTitle` variable to `helpMenuConfig` and document
- publish a new minor version of `primo-explore-help-menu`