### PR TITLE
WEB-218: unpaywall - Allow users to customize link display

### DIFF
--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -24,7 +24,7 @@ $ npm install --save-dev primo-explore-help-menu
 
 this should add the following line to your `package.json` file...
 ```json
-"primo-explore-help-menu": "^1.2.1"
+"primo-explore-help-menu": "^1.2.2"
 ```
 
 and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-help-menu`

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -36,6 +36,16 @@
         }
       },
       {
+        "key": "helpMenuTitle",
+        "type": "input",
+        "defaultValue":"Search Help",
+        "templateOptions": {
+          "required": false,
+          "label": "Page and popup title displayed at the top of the menu (useful for translations)",
+          "placeholder": "Search Help"
+        }
+      },
+      {
         "key": "helpMenuWidth",
         "type": "input",
         "defaultValue":500,

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.1.4",
+  "version": "1.2.2",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [

--- a/packages/unpaywall/README.md
+++ b/packages/unpaywall/README.md
@@ -70,7 +70,7 @@ $ npm install --save-dev primo-explore-unpaywall
 this should add the following line to your `package.json` file...
 
 ```json
-"primo-explore-unpaywall": "^1.2.0"
+"primo-explore-unpaywall": "^1.3.2"
 ```
 
 and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-unpaywall`

--- a/packages/unpaywall/README.md
+++ b/packages/unpaywall/README.md
@@ -127,6 +127,9 @@ the following table describes describes some additional configuration options th
 |`logToConsole`|`true`|controls whether or not messages about what's going on in the component are `console.log()`-ed (visible in inspector)|
 |`showDebugTable`|`false`|the debug table is a quick way to see unpaywall response data for the record in context a really ugly way (used to help troubleshoot, not meant for end users)|
 |`publishEvents`|`false`|we use this variable within our sample implementation to ensure only real traffic is tracked (not us debugging/developing/testing)|
+|`labelText`|_see above_|Text/copy for the main call-to-action|
+|`imageUrl` |`null`|Alternative image to display with unpaywall link|
+|`imageStyle`|_see example_|CSS tweaking to style whatever image you've chosen|
 
 _note: the default for `logEvent` can be found within this repo at `src/.main.js`. it assumes you're using google analytics and calls it via `window.ga`_
 

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -22,7 +22,7 @@
         "type": "input",
         "templateOptions": {
           "required": false,
-          "label": "Text/copy for the main call to action",
+          "label": "Text/copy for the main call-to-action",
           "placeholder": "Open Access available via unpaywall"
         }
       },

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -27,6 +27,24 @@
         }
       },
       {
+        "key": "imageUrl",
+        "type": "input",
+        "templateOptions": {
+          "required": false,
+          "label": "Alternative image to display with unpaywall link",
+          "placeholder": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Open_Access_logo_PLoS_white.svg/384px-Open_Access_logo_PLoS_white.svg.png"
+        }
+      },
+      {
+        "key": "imageStyle",
+        "type": "input",
+        "templateOptions": {
+          "required": false,
+          "label": "CSS tweaking to style whatever image you've chosen",
+          "placeholder": "height: 24px; vertical-align: bottom; padding-right: 5px;"
+        }
+      },
+      {
         "key": "showOnResultsPage",
         "type": "select",
         "defaultValue": true,

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -18,6 +18,15 @@
         }
       },
       {
+        "key": "labelText",
+        "type": "input",
+        "templateOptions": {
+          "required": false,
+          "label": "Text/copy for the main call to action",
+          "placeholder": "Open Access available via unpaywall"
+        }
+      },
+      {
         "key": "showOnResultsPage",
         "type": "select",
         "defaultValue": true,

--- a/packages/unpaywall/features.json
+++ b/packages/unpaywall/features.json
@@ -1,11 +1,11 @@
 {
   "face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
-  "notes": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
+  "notes": "Add Open Access clickthrough link to search-result-avaliability-line via unpaywall",
   "who": "BU Libraries",
   "what": "bulib-unpaywall",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
   "npmid": "primo-explore-unpaywall",
-  "version": "1.2.1",
+  "version": "1.3.2",
   "config": {
     "form": [
       {

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.2.1",
+  "version": "1.3.2",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/src/.main.js
+++ b/packages/unpaywall/src/.main.js
@@ -22,5 +22,7 @@ app.component('prmSearchResultAvailabilityLineAfter', {
     "logEvent":function(category, action, label){
       window.ga('send', 'event', category, action, label);
     },
-    "labelText":"View Open Access Version"
+    "labelText":"View Open Access Version",
+    "imageUrl":"https://upload.wikimedia.org/wikipedia/commons/archive/2/25/20181007070735%21Open_Access_logo_PLoS_white.svg",
+    "imageStyle":"width: 20px; padding-right:5px; vertical-align: middle;"
   });

--- a/packages/unpaywall/src/.main.js
+++ b/packages/unpaywall/src/.main.js
@@ -21,5 +21,6 @@ app.component('prmSearchResultAvailabilityLineAfter', {
     "publishEvents":false,
     "logEvent":function(category, action, label){
       window.ga('send', 'event', category, action, label);
-    }
+    },
+    "labelText":"View Open Access Version"
   });

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -36,6 +36,8 @@ angular.module('bulibUnpaywall', [])
       self.overrideOACheck = (Object.keys(unpaywallConfig).includes("overrideOACheck")) ? unpaywallConfig.overrideOACheck : false;
       self.logEvent = unpaywallConfig.logEvent || logEventToGoogleAnalytics;
 
+      // customize UI/UX
+      self.labelText = (Object.keys(unpaywallConfig).includes("labelText")) ? unpaywallConfig.labelText : "Open Access available via unpaywall";
       // conditionally log to the console
       self.logMessageToConsole = function (message) {
         if (self.logToConsole) { console.log("bulib-unpaywall) " + message); }
@@ -120,7 +122,10 @@ angular.module('bulibUnpaywall', [])
           <a ng-click="$ctrl.trackLinkClick($ctrl.doi)" target="_blank" href="{{$ctrl.best_oa_link}}"\
             style="margin-left: 3px; margin-top: 3px;" rel="noreferrer">\
             <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px" style="color: #f68212;"></prm-icon>\
-            <strong>Open Access</strong> available via unpaywall\
+            \
+            <span ng-if="$ctrl.labelText">{{$ctrl.labelText}}</span>\
+            <span ng-hide="$ctrl.labelText"><strong>Open Access</strong> available via unpaywall</span>\
+            \
             <span ng-if="$ctrl.showVersionLabel && $ctrl.best_oa_version">&nbsp({{$ctrl.best_oa_version}} version)</span>\
             <prm-icon external-link icon-type="svg" svg-icon-set="primo-ui" icon-definition="open-in-new"></prm-icon>\
           </a>\

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -38,6 +38,9 @@ angular.module('bulibUnpaywall', [])
 
       // customize UI/UX
       self.labelText = (Object.keys(unpaywallConfig).includes("labelText")) ? unpaywallConfig.labelText : "Open Access available via unpaywall";
+      self.imageUrl  = (Object.keys(unpaywallConfig).includes("imageUrl")) ? unpaywallConfig.imageUrl : null;
+      self.imageStyle = (Object.keys(unpaywallConfig).includes("imageStyle")) ? unpaywallConfig.imageStyle : "height: 24px; vertical-align: bottom; padding-right: 5px;";
+      
       // conditionally log to the console
       self.logMessageToConsole = function (message) {
         if (self.logToConsole) { console.log("bulib-unpaywall) " + message); }
@@ -121,7 +124,9 @@ angular.module('bulibUnpaywall', [])
         <div layout="flex" ng-if="$ctrl.best_oa_link" class="layout-row" style="margin-top: 5px;">\
           <a ng-click="$ctrl.trackLinkClick($ctrl.doi)" target="_blank" href="{{$ctrl.best_oa_link}}"\
             style="margin-left: 3px; margin-top: 3px;" rel="noreferrer">\
-            <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px" style="color: #f68212;"></prm-icon>\
+            \
+            <img ng-if="$ctrl.imageUrl" src="{{$ctrl.imageUrl}}" alt="unpaywall logo" style="{{$ctrl.imageStyle}}">\
+            <prm-icon ng-hide="$ctrl.imageUrl" icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px" style="color: #f68212;"></prm-icon>\
             \
             <span ng-if="$ctrl.labelText">{{$ctrl.labelText}}</span>\
             <span ng-hide="$ctrl.labelText"><strong>Open Access</strong> available via unpaywall</span>\

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -37,7 +37,7 @@ angular.module('bulibUnpaywall', [])
       self.logEvent = unpaywallConfig.logEvent || logEventToGoogleAnalytics;
 
       // customize UI/UX
-      self.labelText = (Object.keys(unpaywallConfig).includes("labelText")) ? unpaywallConfig.labelText : "Open Access available via unpaywall";
+      self.labelText = (Object.keys(unpaywallConfig).includes("labelText")) ? unpaywallConfig.labelText : null;
       self.imageUrl  = (Object.keys(unpaywallConfig).includes("imageUrl")) ? unpaywallConfig.imageUrl : null;
       self.imageStyle = (Object.keys(unpaywallConfig).includes("imageStyle")) ? unpaywallConfig.imageStyle : "height: 24px; vertical-align: bottom; padding-right: 5px;";
       


### PR DESCRIPTION
Resolves #14 
Resolves #17 

### Description of Changes
- add `labelText` to optionally replace "**Open Access** available via unpaywall"
- add `imageUrl` and `imageStyle` to optionally replace the `lock_open` icon
- make updates to the `features.json` in preparation for `primostudio` 
- publish npm update `1.2.1` -> `1.3.2`

### Screenshot of Changes
![rise of unpaywall paper with customized label and image open access wee](https://user-images.githubusercontent.com/5565284/67687114-2ee52a00-f96e-11e9-8fea-e03a47217741.png)
