### PR TITLE
WEB-201: Open the help-menu from other modules/packages/the console

### DIFF
--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -12,6 +12,18 @@ Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`
 4. links can be made between entries very simply using anchor tags `#{entry.id}`
 5. if desired, users can open the help menu in a new window to enable multi-tasking
 
+_note: as of `1.3.0`, you can open the help menu from any page (or module) by triggering an `openHelpMenuEvent` event!_
+
+```javascript
+window.dispatchEvent(new CustomEvent('openHelpMenuEvent'))
+```
+
+_If you want to specify a particular page, simply add the entry `id` as the event `detail` like so:_
+
+```javascript
+window.dispatchEvent(new CustomEvent('openHelpMenuEvent', {detail:'getting-started'}))
+```
+
 ## Usage
 
 ### Adding the Package to your view in `primo-explore`

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -107,6 +107,12 @@ const mainHelpMenuController = function(helpMenuHelper, $injector, $scope, $time
   // keep listening for changes in the page's 'hash' to see which entry to show (e.g. '/path/to#hash')
   window.addEventListener('hashchange',$scope.setEntryIdFromHash,true);
 
+  // listen for any 'openHelpMenuEvent' to open menu in a new window
+  window.addEventListener('openHelpMenuEvent', function(ev){ 
+    let entry_id = ev.detail || "";
+    helpMenuHelper.logMessage("opening helpMenu from 'openHelpMenuEvent' with 'item_id': '" + entry_id + "'")
+    $scope.openHelpInNewWindow(entry_id); 
+  });
 }
 
 // the simplest-case display for the help-menu when rendered directly into the page (`primo-explore/static-file/help`)


### PR DESCRIPTION
### Description of Changes
- `addEventListener` listen on window for `openHelpMenuEvent`
- allow  open help menu via '$scope.openHelpMenu'
- describe this functionality in the `README`
