### PR TITLE
WEB-256: unpaywall, help-menu - Add 'Code Table' options to replace customization options

### DIFF
--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/src/help-menu-templates.js
+++ b/packages/help-menu/src/help-menu-templates.js
@@ -5,7 +5,7 @@ const helpMenuHeadContent = `
   </md-button>
   <h2>
     <strong ng-if="helpMenuTitle">{{helpMenuTitle}}</strong>
-    <strong ng-hide="helpMenuTitle">Search Help</strong>
+    <strong ng-hide="helpMenuTitle" translate="nui.helpMenu.helpMenuTitle">Search Help</strong>
     <span ng-hide="!entry"> - {{entry.title}}</span>
   </h2>`;
 
@@ -54,7 +54,7 @@ export const helpMenuDialogTemplate = (width) => `
         <div class="md-dialog-content">${helpMenuMainContent}</div>
       </md-dialog-content>
       <md-dialog-actions layout="row">
-        <md-button ng-click="openHelpInNewWindow(entry.id)">Open in New Window</md-button>
+        <md-button ng-click="openHelpInNewWindow(entry.id)" translate="nui.helpMenu.newWindowButtonText">Open in New Window</md-button>
       </md-dialog-actions>
     </form>
   </md-dialog>`;

--- a/packages/unpaywall/package.json
+++ b/packages/unpaywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-unpaywall",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
   "main": "src/unpaywall.module.js",
   "repository": {

--- a/packages/unpaywall/src/unpaywall.module.js
+++ b/packages/unpaywall/src/unpaywall.module.js
@@ -129,7 +129,7 @@ angular.module('bulibUnpaywall', [])
             <prm-icon ng-hide="$ctrl.imageUrl" icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px" style="color: #f68212;"></prm-icon>\
             \
             <span ng-if="$ctrl.labelText">{{$ctrl.labelText}}</span>\
-            <span ng-hide="$ctrl.labelText"><strong>Open Access</strong> available via unpaywall</span>\
+            <span ng-hide="$ctrl.labelText" translate="nui.unpaywall.labelText"><strong>Open Access</strong> available via unpaywall</span>\
             \
             <span ng-if="$ctrl.showVersionLabel && $ctrl.best_oa_version">&nbsp({{$ctrl.best_oa_version}} version)</span>\
             <prm-icon external-link icon-type="svg" svg-icon-set="primo-ui" icon-definition="open-in-new"></prm-icon>\


### PR DESCRIPTION
Jira Ticket: [WEB-256](https://bulibrary.atlassian.net/browse/WEB-256)

### Background
- primo provides Code Tables to enable the reading and writing of values between the admin UI (back office) and the code itself (customization package)
- we currently provide ways to customize various parts of each addon through a config (customization package), but not the Code Tables

### Description of Changes
- add `nui.helpMenu` and 
- add `nui.unpaywall` Code Table value within `Code Tables > FRONTEND > Results Tile' 