### PR TITLE
WEB-356: help-menu - Add a 'notification-indicator' with show/hide functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,8 +21,14 @@ angular.module('viewCustom', module_dependencies)
   .constant('helpMenuConfig', {
     "logToConsole":!ENV_PRODUCTION,
     "publishEvents":ENV_PRODUCTION,
-    "list_of_elements":ls_help_menu_items,
-    "helpMenuWidth":550
+    "helpMenuTitle":"Search Menu",
+    "helpMenuWidth":500,
+    "list_of_elements":help_menu_items,
+    "enableNotificationIndicator":true,
+    "notificationIndicatorExpiration": 1000 * 60 * 60 * 24 * 7 * 2,  // 2 weeks
+    "logEventToAnalytics":function(category, action, label){
+      window.ga('send', 'event', category, action, label);
+    }
   })
 
   // configure outboundLinksConfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-bu",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "assorted customizations to Ex Libris Primo New UI created, consumed, and maintained by BU Libraries.",
   "files": [
     "main.js",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bulib/primo-explore-bu#readme",
   "dependencies": {
-    "primo-explore-help-menu": "^1.4.1",
+    "primo-explore-help-menu": "^1.5.0",
     "primo-explore-outbound-links": "^0.6.0",
     "primo-explore-unpaywall": "^1.4.1"
   },

--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -60,8 +60,17 @@ angular.module('viewCustom', ['angularLoad', 'helpMenuContentDisplay',  'helpMen
 ### Additional Steps
 
 To get the same styling, you'll have to copy or import the `help-menu.css` file to the `css/custom.css` for your view.
+  to automate this, add the following `script` to your `package.json`:
+
+```json
+  "postinstall": "cp node_modules/primo-explore-help-menu/dist/help-menu.css ./css/help-menu.css"
+```
   
-If you're using a version from `1.1.0` onward, you'll have to make sure there's a `html/help_en_US.html` included as well.
+If you're using a version from `1.1.0` onward, you'll have to make sure there's a `html/help_en_US.html` included as well
+
+```bash
+$ touch html/help_en_US.html
+```
 
 ### Adding Your Own Content
 
@@ -86,7 +95,7 @@ Make sure that each object in the list of elements matches the following structu
 }
 ```
 
-...including intentionally empty objects in the list (`{}`) to form the dividers.
+...include intentionally empty objects in the list (`{}`) to form the dividers.
 
 _note: the [iconset being used](https://material.io/tools/icons/) is from material.io and is included within primo_
 
@@ -102,6 +111,8 @@ the following table describes describes some additional configuration options th
 |`logEventToAnalytics`|_see example_|here's an opportunity to hook in whatever event tracking you have, (we use google analytics)|
 |`helpMenuTitle`|`Search Help`|page and popup title displayed at the top of the menu (useful for translations) |
 |`helpMenuWidth`|`500` (px)|the width of the dialog box and associated popup|
+|`enableNotificationIndicator`|`false`|visually highlight the top-bar icon for new users until they open and dismiss it|
+|`notificationIndicatorExpiration`|2 weeks|set the amount of time it takes before the notification dismissal resets|
 
 ## Events Logged
 

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.2.2",
+  "version": "1.4.3",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [
@@ -28,6 +28,19 @@
         "defaultValue": false,
         "templateOptions": {
           "label": "(debug) Determine whether click/usage events are published to Analytics",
+          "required": false,
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "enableNotificationIndicator",
+        "type": "select",
+        "defaultValue": false,
+        "templateOptions": {
+          "label": "highlight the icon for new users until they open and dismiss it",
           "required": false,
           "options": [
             { "name": "true",  "value": true  },

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [
@@ -36,19 +36,6 @@
         }
       },
       {
-        "key": "enableNotificationIndicator",
-        "type": "select",
-        "defaultValue": false,
-        "templateOptions": {
-          "label": "highlight the icon for new users until they open and dismiss it",
-          "required": false,
-          "options": [
-            { "name": "true",  "value": true  },
-            { "name": "false", "value": false }
-          ]
-        }
-      },
-      {
         "key": "helpMenuTitle",
         "type": "input",
         "defaultValue":"Search Help",
@@ -69,6 +56,29 @@
         }
       },
       {"key":"list_of_elements"},
+      {
+        "key": "enableNotificationIndicator",
+        "type": "select",
+        "defaultValue": false,
+        "templateOptions": {
+          "label": "visually highlight the top-bar icon for new users until they open and dismiss it",
+          "required": false,
+          "options": [
+            { "name": "true",  "value": true  },
+            { "name": "false", "value": false }
+          ]
+        }
+      },
+      {
+        "key": "notificationIndicatorExpiration",
+        "type": "input",
+        "defaultValue":"1209600000",
+        "templateOptions": {
+          "required": false,
+          "label": "set the amount of time it takes before the notification dismissal resets (in milliseconds)",
+          "placeholder": "1000*60*60*24*7*2"
+        }
+      },
       {"key":"logEventToAnalytics"}
     ]
   }

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/src/.main.js
+++ b/packages/help-menu/src/.main.js
@@ -1,8 +1,5 @@
-// import npm package by name (from `node_modules/`)
+// import npm package by name (after `$ npm install --save-dev primo-explore-help-menu` is run)
 import 'primo-explore-help-menu';
-
-// import copy/pasted 'help-menu.js' in js/
-// import '../node_modules/primo-explore-help-menu/dist/help-menu';
 
 // import list of help-menu entries from another js file
 import {help_menu_items} from './help-menu-content';
@@ -15,6 +12,8 @@ app.constant('helpMenuConfig', {
   "list_of_elements":help_menu_items,
   "logToConsole":true,
   "publishEvents":false,
+  "enableNotificationIndicator":true,
+  "notificationIndicatorExpiration": 1000 * 60 * 60 * 24 * 7 * 2,  // 2 weeks
   "helpMenuTitle":"Search Menu",
   "helpMenuWidth":500,
   "logEventToAnalytics":function(category, action, label){

--- a/packages/help-menu/src/help-menu.css
+++ b/packages/help-menu/src/help-menu.css
@@ -20,3 +20,19 @@ a.helpMenu--location-button {
 div.helpMenu--location{
   padding-bottom: 10px;
 }
+
+help-menu-topbar { 
+  --notification-indicator-display: none;
+  --notification-indicator-color: red;
+}
+
+help-menu-topbar .notification-indicator {
+  display: var(--notification-indicator-display, none);
+  background-color: var(--notification-indicator-color, red);
+  
+  position: fixed;
+  margin-left: 32px;
+  top: 17px;
+  height: 10px; width: 10px;
+  border-radius: 50%;
+}

--- a/packages/help-menu/src/help-menu.css
+++ b/packages/help-menu/src/help-menu.css
@@ -30,7 +30,7 @@ help-menu-topbar .notification-indicator {
   display: var(--notification-indicator-display, none);
   background-color: var(--notification-indicator-color, red);
   
-  position: fixed;
+  position: absolute;
   margin-left: 32px;
   top: 17px;
   height: 10px; width: 10px;

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -57,7 +57,7 @@ let helpMenuHelper = {
       }
     }
     // if there's an error or localStorage is disabled, default to dismissed
-    catch(err){ console.log(err); return true; }
+    catch(err){ this.logMessage(err); return true; }
   },
   showNotificationIndicatorIfNotDismissed: function(){
     if(this.enableNotificationIndicator && !this.isNotificationDismissed()){
@@ -67,9 +67,11 @@ let helpMenuHelper = {
   },
   dismissNotificationIndicator: function(){
     try{  // add dismissed value to localStorage and hide the indicator with the css variable 
-      window.localStorage.setItem(localStorageVariableName, Date.now());
-      document.querySelector("help-menu-topbar").style.setProperty(cssVariableName, "none");
-      this.logMessage("notification-indicator dismissed");
+      if(this.enableNotificationIndicator){
+        window.localStorage.setItem(localStorageVariableName, Date.now());
+        document.querySelector("help-menu-topbar").style.setProperty(cssVariableName, "none");
+        this.logMessage("notification-indicator dismissed");
+      }
     }catch(err){ this.logMessage(err); }
   },
   get_entry_by_id: function(id){

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -173,6 +173,7 @@ angular.module('helpMenuTopbar', ['ngMaterial'])
             <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_help_24px"></prm-icon>
           </a>
         </div>
+        <span class="notification-indicator"></span>
       </help-menu-topbar>`,
     controller: 'helpMenuTopbarController'
   });


### PR DESCRIPTION
Jira Ticket: [WEB-356](https://bulibrary.atlassian.net/browse/WEB-356)

### Background:
- after deploying the help-menu to our staging environment, we found less usage than we expected
- we decided to leverage patrons' familiarity with responding to notifications in the top right (facebook, various other social media) as a way to highlight the menu for new users

### Description of Changes
- [x] add a new `span.notification-indicator` to the `help-menu-topbar`
- [x] configure display to show/hide with css variable and `localStorage`
- [x] add a setting (defaulted to `false`) to `enableNotificationIndicator`
- [x] set a configurable expiration (`notificationIndicatorExpiration`) that removes the dismissal over time 

### Screenshots
shown and not shown based on `localStorage`
![shown and not shown](https://user-images.githubusercontent.com/5565284/84408360-05fe6600-abda-11ea-91a3-f0ea688af885.png)

looks similar at different sizes:
![sizes](https://user-images.githubusercontent.com/5565284/84408949-cd12c100-abda-11ea-8d6a-e03730a29679.png)


