### PR TITLE
help-menu: [WEB-393] add 'helpContentUpdates' with headings

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 import { 
   ENV_PRODUCTION, INCLUDE_UNPAYWALL, INCLUDE_OUTBOUND_LINKS, INCLUDE_HELP_MENU 
 } from './config.js';
+import {sample_list_of_updates, sample_list_of_items} from './packages/help-menu/src/help-menu-content';
 
 // import npm packages
 import 'primo-explore-help-menu';
@@ -21,11 +22,17 @@ angular.module('viewCustom', module_dependencies)
   .constant('helpMenuConfig', {
     "logToConsole":!ENV_PRODUCTION,
     "publishEvents":ENV_PRODUCTION,
+
     "helpMenuTitle":"Search Menu",
     "helpMenuWidth":500,
-    "list_of_elements":help_menu_items,
+    "updatesLabel":"Search Updates",
+    "list_of_updates":sample_list_of_updates,
+    "entriesLabel":"Help Entries",
+    "list_of_elements":sample_list_of_items,
+
     "enableNotificationIndicator":true,
     "notificationIndicatorExpiration": 1000 * 60 * 60 * 24 * 7 * 2,  // 2 weeks
+
     "logEventToAnalytics":function(category, action, label){
       window.ga('send', 'event', category, action, label);
     }

--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -36,7 +36,7 @@ $ npm install --save-dev primo-explore-help-menu
 
 this should add the following line to your `package.json` file...
 ```json
-"primo-explore-help-menu": "^1.2.2"
+"primo-explore-help-menu": "^1.X.X"
 ```
 
 and add the contents of this repository (at that npm version) into a `node_modules/primo-explore-help-menu`
@@ -98,6 +98,17 @@ Make sure that each object in the list of elements matches the following structu
 ...include intentionally empty objects in the list (`{}`) to form the dividers.
 
 _note: the [iconset being used](https://material.io/tools/icons/) is from material.io and is included within primo_
+
+As of `1.6.0`, you can also specify a `list_of_updates` variable with the same structure to highlight a number of
+  items above the other entries. At BU, we use this feature to highlight recent changes to the platform or big 
+  pieces of library news.
+
+```js
+// main.js
+import {my_custom_list_of_updates} from 'my_long_list_of_json_objects';
+
+app.constant('helpMenuConfig', { "list_of_updates": my_custom_list_of_updates });
+```
 
 ### Additional Customization
 

--- a/packages/help-menu/README.md
+++ b/packages/help-menu/README.md
@@ -124,6 +124,8 @@ the following table describes describes some additional configuration options th
 |`helpMenuWidth`|`500` (px)|the width of the dialog box and associated popup|
 |`enableNotificationIndicator`|`false`|visually highlight the top-bar icon for new users until they open and dismiss it|
 |`notificationIndicatorExpiration`|2 weeks|set the amount of time it takes before the notification dismissal resets|
+|`updatesLabel`|`Search Updates`|Heading text for shortlist of updates above help entries|
+|`entriesLabel`|`Help Entries`|Heading text for main help entries (only appears when there's a list of updates)|
 
 ## Events Logged
 

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [
@@ -55,8 +55,28 @@
           "placeholder": 500
         }
       },
-      {"key":"list_of_updates"},
+      {
+        "key": "updatesLabel",
+        "type": "input",
+        "defaultValue":"Search Updates",
+        "templateOptions": {
+          "required": false,
+          "label": "Heading text for shortlist of updates above help entries",
+          "placeholder": "Search Updates"
+        }
+      },
       {"key":"list_of_elements"},
+      {
+        "key": "entriesLabel",
+        "type": "input",
+        "defaultValue":"Help Entries",
+        "templateOptions": {
+          "required": false,
+          "label": "Heading text for main help entries (only appears when there's a list of updates)",
+          "placeholder": "Help Entries"
+        }
+      },
+      {"key":"list_of_updates"},
       {
         "key": "enableNotificationIndicator",
         "type": "select",

--- a/packages/help-menu/features.json
+++ b/packages/help-menu/features.json
@@ -5,7 +5,7 @@
   "what": "help-menu-topbar",
   "linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
   "npmid": "primo-explore-help-menu",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "hook": "prm-search-bookmark-filter-after",
   "config": {
     "form": [
@@ -55,6 +55,7 @@
           "placeholder": 500
         }
       },
+      {"key":"list_of_updates"},
       {"key":"list_of_elements"},
       {
         "key": "enableNotificationIndicator",

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
-  "description": "Add link to customizable 'help-menu' popup to `prm-search-bookmark-filter-after`",
-  "version": "1.5.1",
+  "description": "Add customizable 'help-menu' to `prm-search-bookmark-filter-after`",
+  "version": "1.6.0",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add customizable 'help-menu' to `prm-search-bookmark-filter-after`",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/package.json
+++ b/packages/help-menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primo-explore-help-menu",
   "description": "Add customizable 'help-menu' to `prm-search-bookmark-filter-after`",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "./dist/help-menu.js",
   "files": [
     "dist"

--- a/packages/help-menu/src/.main.js
+++ b/packages/help-menu/src/.main.js
@@ -2,14 +2,15 @@
 import 'primo-explore-help-menu';
 
 // import list of help-menu entries from another js file
-import {help_menu_items} from './help-menu-content';
+import {sample_list_of_updates, sample_list_of_items} from './help-menu-content';
 
 //load app 'viewCustom' as a module with [] dependencies
 var app = angular.module('viewCustom', ['angularLoad', 'helpMenuContentDisplay',  'helpMenuTopbar']);
 
 // - configure help-menu - //
 app.constant('helpMenuConfig', {
-  "list_of_elements":help_menu_items,
+  "list_of_updates": sample_list_of_updates,
+  "list_of_elements":sample_list_of_items,
   "logToConsole":true,
   "publishEvents":false,
   "enableNotificationIndicator":true,

--- a/packages/help-menu/src/.main.js
+++ b/packages/help-menu/src/.main.js
@@ -9,13 +9,18 @@ var app = angular.module('viewCustom', ['angularLoad', 'helpMenuContentDisplay',
 
 // - configure help-menu - //
 app.constant('helpMenuConfig', {
-  "list_of_updates": sample_list_of_updates,
-  "list_of_elements":sample_list_of_items,
   "logToConsole":true,
   "publishEvents":false,
+
   "enableNotificationIndicator":true,
   "notificationIndicatorExpiration": 1000 * 60 * 60 * 24 * 7 * 2,  // 2 weeks
+
   "helpMenuTitle":"Search Menu",
+  "updatesLabel":"Search Updates",
+  "list_of_updates": sample_list_of_updates,
+  "entriesLabel":"Help Entries",
+  "list_of_elements":sample_list_of_items,
+  
   "helpMenuWidth":500,
   "logEventToAnalytics":function(category, action, label){
     window.ga('send', 'event', category, action, label);

--- a/packages/help-menu/src/help-menu-content.js
+++ b/packages/help-menu/src/help-menu-content.js
@@ -1,3 +1,36 @@
+export const sample_list_of_updates = [
+  {
+    "id":"hathitrust-availability",
+    "title":"Hathi Trust Availability ETAS",
+    "description":"the hathitrust emergency temporary access service (ETAS) allows online reading access to selected materials",
+    "icon":{"code":"mediation","group":"action"},
+    "template":`
+      <h3>About the HathiTrust Emergency Temporary Access Service (ETAS)</h3>
+      <p>The HathiTrust Emergency Temporary Access Service (ETAS) allows current BU students, faculty, and staff to have <strong>online reading access to selected materials that are in the BU Libraries but are currently unavailable due to the closure of the Libraries</strong>.</p>
+      <p>Faculty, students, and staff can access these materials via <a href="http://library.bu.edu/buls">BU Libraries Search</a>. Physical books in BU Libraries that are also available via HathiTrust will have a “<strong>Full Text Available at HathiTrust</strong>” link included in their records in BU Libraries Search.</p>
+      <p class="big-text"><strong>Access to these books is a multi-step process. Please follow the steps outlined below to read the books online.</strong></p>
+      <h3>How to Access Books via HathiTrust</h3>
+      <p>
+        Faculty, students, and staff can access these materials via BU Libraries Search. Physical books in BU Libraries that are also available via 
+        HathiTrust will have a “<strong>Full Text Available at HathiTrust</strong>” link included in their records in BU Libraries Search. 
+        <em>(Note: This link will also be shown for out-of-copyright items; for those items the link will take you directly to the item without having to follow the steps below.)</em>
+      </p>
+    `
+  },
+  {
+    "id":"visiting-the-libraries",
+    "title":"Visiting the Libraries",
+    "description":"discussion of covid-related changes to bu libraries operation",
+    "icon":{"code":"business","group":"communication"},
+    "template":`
+      <h2>Try Online First</h2>
+      <p>
+        Our building capacity has been significantly reduced to comply with public health guidelines. To avoid long waits, try connecting with us online 
+        before you come to our physical locations. We have expanded our online service delivery and may be able to help you without a visit to one of our branches. 
+      </p>
+    `
+  }
+];
 export const sample_list_of_elements = [
   {
     "id":"getting-started",

--- a/packages/help-menu/src/help-menu-templates.js
+++ b/packages/help-menu/src/help-menu-templates.js
@@ -15,7 +15,7 @@ const helpMenuMainContent = `
     <p ng-if="!entry.template"><em>{{entry.description}}</em></p>
     <div ng-bind-html="entry.template"></div>
   </div>
-  <h2 ng-hide="entry || !helpContentUpdates" class="mtl">Search Updates</h2>
+  <h2 ng-hide="entry || !helpContentUpdates">Search Updates</h2>
   <ul ng-hide="entry || !helpContentUpdates" style="list-style: none; width: 100%; padding-left: 0px;">
     <hr aria-hidden="true" />
     <li ng-repeat="item in helpContentUpdates" class="row">
@@ -28,7 +28,7 @@ const helpMenuMainContent = `
     </li>
     <hr aria-hidden="true" />
   </ul>
-  <h2 ng-hide="entry || !helpContentList" class="mtl">Help Entries</h2>
+  <h2 ng-hide="entry || !helpContentList || !helpContentUpdates">Help Entries</h2>
   <ul ng-hide="entry || !helpContentList" style="list-style: none; width: 100%; padding-left: 0px;">
     <hr aria-hidden="true" />
     <li ng-repeat="item in helpContentList" class="row">

--- a/packages/help-menu/src/help-menu-templates.js
+++ b/packages/help-menu/src/help-menu-templates.js
@@ -15,7 +15,7 @@ const helpMenuMainContent = `
     <p ng-if="!entry.template"><em>{{entry.description}}</em></p>
     <div ng-bind-html="entry.template"></div>
   </div>
-  <h2 ng-hide="entry || !helpContentUpdates">Search Updates</h2>
+  <h2 ng-hide="entry || !helpContentUpdates">{{updatesLabel}}</h2>
   <ul ng-hide="entry || !helpContentUpdates" style="list-style: none; width: 100%; padding-left: 0px;">
     <hr aria-hidden="true" />
     <li ng-repeat="item in helpContentUpdates" class="row">
@@ -28,7 +28,7 @@ const helpMenuMainContent = `
     </li>
     <hr aria-hidden="true" />
   </ul>
-  <h2 ng-hide="entry || !helpContentList || !helpContentUpdates">Help Entries</h2>
+  <h2 ng-hide="entry || !helpContentList || !helpContentUpdates">{{entriesLabel}}</h2>
   <ul ng-hide="entry || !helpContentList" style="list-style: none; width: 100%; padding-left: 0px;">
     <hr aria-hidden="true" />
     <li ng-repeat="item in helpContentList" class="row">

--- a/packages/help-menu/src/help-menu-templates.js
+++ b/packages/help-menu/src/help-menu-templates.js
@@ -3,11 +3,11 @@ const helpMenuHeadContent = `
     <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_arrow_back_24px"
               aria-label="return to help content list" ></prm-icon>
   </md-button>
-  <h2>
+  <h1>
     <strong ng-if="helpMenuTitle">{{helpMenuTitle}}</strong>
     <strong ng-hide="helpMenuTitle">Search Help</strong>
     <span ng-hide="!entry"> - {{entry.title}}</span>
-  </h2>`;
+  </h1>`;
 
 const helpMenuMainContent = `
   <div ng-if="entry" id="search-help-menu-content" tabindex="-1">
@@ -15,7 +15,21 @@ const helpMenuMainContent = `
     <p ng-if="!entry.template"><em>{{entry.description}}</em></p>
     <div ng-bind-html="entry.template"></div>
   </div>
-  <ul ng-hide="entry" style="list-style: none; width: 100%; padding-left: 0px;">
+  <h2 ng-hide="entry || !helpContentUpdates" class="mtl">Search Updates</h2>
+  <ul ng-hide="entry || !helpContentUpdates" style="list-style: none; width: 100%; padding-left: 0px;">
+    <hr aria-hidden="true" />
+    <li ng-repeat="item in helpContentUpdates" class="row">
+      <a ng-if="item.id" href="#{{item.id}}">
+        <prm-icon svg-icon-set="{{item.icon.group}}" icon-definition="ic_{{item.icon.code}}_24px"
+                  icon-type="svg" style="padding-right: 10px;"></prm-icon>
+        {{item.title}}
+      </a>
+      <hr ng-if="!item.id" aria-hidden="true" />
+    </li>
+    <hr aria-hidden="true" />
+  </ul>
+  <h2 ng-hide="entry || !helpContentList" class="mtl">Help Entries</h2>
+  <ul ng-hide="entry || !helpContentList" style="list-style: none; width: 100%; padding-left: 0px;">
     <hr aria-hidden="true" />
     <li ng-repeat="item in helpContentList" class="row">
       <a ng-if="item.id" href="#{{item.id}}">

--- a/packages/help-menu/src/help-menu.css
+++ b/packages/help-menu/src/help-menu.css
@@ -3,27 +3,28 @@
 #search-help-menu-content h2 {font-weight: 500;}
 #search-help-menu-content h3 {font-weight: 400;}
 #search-help-menu-content img {
-  border: 2px solid #999999;
+  border: 2px solid var(--color-secondary-background-dark, #999999);
   border-radius: 4px;
-  margin: 20px;
+  max-width: 95%;
+  margin: 10px;
   padding: 10px;
 }
 a.helpMenu--location-button {
   padding: 6px;
-  background-color: #22647B;
+  background-color: var(--color-button-background, #22647B);
   border-radius: 4px;
   color: #ffffff;
   text-transform: uppercase;
   box-shadow: 2px 2px 2px 1px rgba(0, 0, 255, .2);
 }
 
-div.helpMenu--location{
+div.helpMenu--location {
   padding-bottom: 10px;
 }
 
 help-menu-topbar { 
   --notification-indicator-display: none;
-  --notification-indicator-color: red;
+  --notification-indicator-color: var(--color-accent-red-background, red);
 }
 
 help-menu-topbar .notification-indicator {

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -19,10 +19,15 @@ const logEventToGoogleAnalytics = function(category, action, label){
 let helpMenuHelper = {
   logToConsole: false,
   publishEvents: false,
-  helpMenuWidth: 500,
+
   enableNotificationIndicator: false,
   notificationIndicatorExpiration: DEFAULT_STORAGE_EXPIRATION_TIME,
+  
+  updatesLabel: "Search Updates",
+  entriesLabel: "Help Entries",
   list_of_elements: sample_list_of_elements,
+  
+  helpMenuWidth: 500,
   logMessage: function(message){
     if(this.logToConsole){ console.log("bulib-help-menu) " + message); }
   },
@@ -94,7 +99,9 @@ let helpMenuHelper = {
     if(Object.keys(config).includes("helpMenuWidth")){ this.helpMenuWidth = config.helpMenuWidth; }
     if(Object.keys(config).includes("helpMenuTitle")){ this.helpMenuTitle = config.helpMenuTitle; }
     if(Object.keys(config).includes("logEventToAnalytics")){ this.logEventToAnalytics = config.logEventToAnalytics; }
+    if(Object.keys(config).includes("entriesLabel")){ this.entriesLabel = config.entriesLabel; }
     if(Object.keys(config).includes("list_of_elements")){ this.list_of_elements = config.list_of_elements; }
+    if(Object.keys(config).includes("updatesLabel")){ this.updatesLabel = config.updatesLabel; }
     if(Object.keys(config).includes("list_of_updates")){ this.list_of_updates = config.list_of_updates; }
   }
 };
@@ -109,9 +116,11 @@ const mainHelpMenuController = function(helpMenuHelper, $injector, $scope, $time
   helpMenuHelper.override_with_config(config);
 
   // gather items in list from helpMenuHelper
-  $scope.helpContentUpdates = helpMenuHelper.list_of_updates;
-  $scope.helpContentList = helpMenuHelper.list_of_elements;
   $scope.helpMenuTitle = helpMenuHelper.helpMenuTitle;
+  $scope.entriesLabel = helpMenuHelper.entriesLabel;
+  $scope.helpContentList = helpMenuHelper.list_of_elements;
+  $scope.updatesLabel = helpMenuHelper.updatesLabel;
+  $scope.helpContentUpdates = helpMenuHelper.list_of_updates;
 
   // modal navigation
   $scope.hide = function() { $mdDialog.hide(); };

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -1,4 +1,4 @@
-import {sample_list_of_elements} from './help-menu-content';
+import {sample_list_of_elements, sample_list_of_updates} from './help-menu-content';
 import {helpMenuContentDisplayTemplate, helpMenuDialogTemplate} from './help-menu-templates';
 
 // handle optional configuration variables
@@ -23,6 +23,7 @@ let helpMenuHelper = {
   enableNotificationIndicator: false,
   notificationIndicatorExpiration: DEFAULT_STORAGE_EXPIRATION_TIME,
   list_of_elements: sample_list_of_elements,
+  list_of_updates: sample_list_of_updates,
   logMessage: function(message){
     if(this.logToConsole){ console.log("bulib-help-menu) " + message); }
   },
@@ -79,6 +80,9 @@ let helpMenuHelper = {
     for(let i=0; i<this.list_of_elements.length; i++){
       if(this.list_of_elements[i].id === id){ return this.list_of_elements[i]; }
     }
+    for(let i=0; i<this.list_of_updates.length; i++){
+      if(this.list_of_updates[i].id === id){ return this.list_of_updates[i]; }
+    }
     return {}
   },
   override_with_config: function(config){
@@ -92,6 +96,7 @@ let helpMenuHelper = {
     if(Object.keys(config).includes("helpMenuTitle")){ this.helpMenuTitle = config.helpMenuTitle; }
     if(Object.keys(config).includes("logEventToAnalytics")){ this.logEventToAnalytics = config.logEventToAnalytics; }
     if(Object.keys(config).includes("list_of_elements")){ this.list_of_elements = config.list_of_elements; }
+    if(Object.keys(config).includes("list_of_updates")){ this.list_of_updates = config.list_of_updates; }
   }
 };
 
@@ -105,6 +110,7 @@ const mainHelpMenuController = function(helpMenuHelper, $injector, $scope, $time
   helpMenuHelper.override_with_config(config);
 
   // gather items in list from helpMenuHelper
+  $scope.helpContentUpdates = helpMenuHelper.list_of_updates;
   $scope.helpContentList = helpMenuHelper.list_of_elements;
   $scope.helpMenuTitle = helpMenuHelper.helpMenuTitle;
 

--- a/packages/help-menu/src/help-menu.module.js
+++ b/packages/help-menu/src/help-menu.module.js
@@ -23,7 +23,6 @@ let helpMenuHelper = {
   enableNotificationIndicator: false,
   notificationIndicatorExpiration: DEFAULT_STORAGE_EXPIRATION_TIME,
   list_of_elements: sample_list_of_elements,
-  list_of_updates: sample_list_of_updates,
   logMessage: function(message){
     if(this.logToConsole){ console.log("bulib-help-menu) " + message); }
   },


### PR DESCRIPTION
Jira Ticket: [WEB-393](https://bulibrary.atlassian.net/browse/WEB-393)

Background:
- we'd like to show a shorter list of updates about our search within the menu

Description of Changes:
- create a new set of sections/headings (conditional) to enable a separate list of items
- preserve defaults 

![search help menu changes](https://user-images.githubusercontent.com/5565284/91357492-4e7ff580-e7bf-11ea-9a14-e3a325c42b70.png)
